### PR TITLE
Feature/ssim interpolation

### DIFF
--- a/scripts/prompt_travel.py
+++ b/scripts/prompt_travel.py
@@ -3,6 +3,7 @@
 
 LOG_PREFIX = '[Prompt-Travel]'
 
+import inspect
 import os
 from pathlib import Path
 from PIL.Image import Image as PILImage
@@ -685,7 +686,7 @@ class Script(scripts.Script):
             # Step 3: append the final stage
             if self.genesis != Gensis.SUCCESSIVE: self.images.extend(imgs)
 
-            if self.ssim_diff > 0:
+            if self.ssim_diff > 0 and self.genesis == Gensis.FIXED:
                 # SSIM
                 (
                     skip_count,
@@ -941,6 +942,7 @@ class Script(scripts.Script):
 
                     if d2 > d or d2 < ssim_diff * ssim_diff_min / 100.0:
                         # Keep image if it is improvment or hasn't reached desired min ssim_diff
+                        #scribble_debug(image, f"{i+1}:{new_dist}")
                         prompt_images.insert(i + 1, image)
                         dists.insert(i + 1, new_dist)
 
@@ -1025,3 +1027,13 @@ class Script(scripts.Script):
 
     def ext_depth_postprocess(self, p:Processing, depth_img:PILImage):
         depth_img.close()
+
+def scribble_debug(image: PILImage, txt: str):
+    """Draws text on image for dev tests"""
+    from PIL import Image, ImageDraw
+    from modules import images
+    draw = ImageDraw.Draw(image)
+    fnt = images.get_font(14)
+    box = draw.textbbox((12, 12), txt, font=fnt)
+    draw.rounded_rectangle(box, radius=4, fill="black")
+    draw.text((12, 12), txt, fill="white", font=fnt)

--- a/scripts/prompt_travel.py
+++ b/scripts/prompt_travel.py
@@ -258,50 +258,10 @@ def update_img2img_p(p:Processing, imgs:PILImages, denoising_strength:float=0.75
         return p
 
     if isinstance(p, ProcessingTxt2Img):
-        KNOWN_KEYS = [      # see `StableDiffusionProcessing.__init__()`
-            'sd_model',
-            'outpath_samples',
-            'outpath_grids',
-            'prompt',
-            'styles',
-            'seed',
-            'subseed',
-            'subseed_strength',
-            'seed_resize_from_h',
-            'seed_resize_from_w',
-            'seed_enable_extras',
-            'sampler_name',
-            'batch_size',
-            'n_iter',
-            'steps',
-            'cfg_scale',
-            'width',
-            'height',
-            'restore_faces',
-            'tiling',
-            'do_not_save_samples',
-            'do_not_save_grid',
-            'extra_generation_params',
-            'overlay_images',
-            'negative_prompt',
-            'eta',
-            'do_not_reload_embeddings',
-            #'denoising_strength',
-            'ddim_discretize',
-            's_min_uncond',
-            's_churn',
-            's_tmax',
-            's_tmin',
-            's_noise',
-            'override_settings',
-            'override_settings_restore_afterwards',
-            'sampler_index',
-            'script_args',
-        ]
-        kwargs = { k: getattr(p, k) for k in dir(p) if k in KNOWN_KEYS }    # inherit params
+        kwargs = {k: getattr(p, k) for k in dir(p) if k in inspect.signature(ProcessingImg2Img).parameters}    # inherit params
+        kwargs['denoising_strength'] = denoising_strength
         return ProcessingImg2Img(
             init_images=imgs,
-            denoising_strength=denoising_strength,
             **kwargs,
         )
 

--- a/scripts/prompt_travel.py
+++ b/scripts/prompt_travel.py
@@ -473,8 +473,7 @@ class Script(scripts.Script):
                 " generate the steps you've specified above,                 but then"
                 " take a second pass and fill in the gaps between images that differ"
                 " too much according to Structual Similarity Index Metric \n           "
-                "         *Only implemented for linear travel and only for fixed or"
-                " successive frame genesis*"
+                " *Only implemented for linear travel and only for fixed frame genesis*"
             )
             ssim_diff = gr.Slider(
                 label="SSIM threshold", value=0.0, minimum=0.0, maximum=1.0, step=0.01


### PR DESCRIPTION
Copies the ssim algorithm from the "shift-attention" plugin for the linear fixed process. If enabled it tries to keep the difference between successive frames below a certain difference threshold. This is different from just raising the number of frames per stage, as it adds more frames when the image changes faster from step to step and less when it changes slow.
**Without ssim**:

https://github.com/Kahsolt/stable-diffusion-webui-prompt-travel/assets/1095756/1d4a92cc-a1fe-425e-b036-7ce5657d2f67


**With ssim (threshold 0.5) enabled**:

https://github.com/Kahsolt/stable-diffusion-webui-prompt-travel/assets/1095756/03d2c99e-dd8b-472c-93be-97a0f74986a3



* Also fixes deprecated "script_args" parameter by just getting the possible parameters by looking with "inspect"